### PR TITLE
Implement math.isqrt stdlib method

### DIFF
--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,40 +1,38 @@
 package python;
+
 import java.lang.Math;
 
-@org.python.Module(
-        __doc__ =
-                "TODO: Write me!"
-)
+@org.python.Module(__doc__ = "This module provides access to the mathematical functions defined by the C standard.\n"+
+"These functions cannot be used with complex numbers; use the functions of the same name from the cmath module if you require support for complex numbers.\n"+
+"The distinction between functions which support complex numbers and those which don’t\n"+
+"is made since most users do not want to learn quite as much mathematics as required to understand complex numbers\n."+ 
+"Receiving an exception instead of a complex result allows earlier detection of the unexpected complex number used as a parameter,\n"+ 
+"so that the programmer can determine how and why it was generated in the first place.")
 public class math extends org.python.types.Module {
     public math() {
         super();
     }
 
-
     @org.python.Attribute
     public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");
-    // @org.python.Attribute
-    // public static org.python.Object __loader__ = org.python.types.NoneType.NONE;
     @org.python.Attribute
     public static org.python.Object __name__ = new org.python.types.Str("math");
-    // @org.python.Attribute
-    // public static org.python.Object __package__ = new org.python.types.Str("");
-    // @org.python.Attribute
-    // public static org.python.Object __spec__ = org.python.types.NoneType.NONE;
+   
 
-    @org.python.Method(
-         __doc__ = "Return the integer square root of the nonnegative integer n. This is the floor of the exact square root of n, or equivalently the greatest integer a such that a² ≤ n.",
-         args = {"n"}
-    )
+    @org.python.Method(__doc__ = "isqrt(n) -> int\n\n"
+            + "Return the integer square root of the nonnegative integer n.\n"
+            + "This is the floor of the exact square root of n\n"
+            + "or equivalently the greatest integer a such that a² ≤ n.", 
+            args = { "n" })
     public static org.python.Object isqrt(org.python.Object n) {
-       if (n instanceof org.python.types.Int) {
-           long n_val = ((org.python.types.Int) n.__int__()).value;
-           if (n_val < 0) {
-             throw new org.python.exceptions.ValueError("math.isqrt only supports nonnegative integers.");
-           }
-           return org.python.types.Int.getInt(((long) Math.floor(Math.sqrt(n_val))));
-       }
-       throw new org.python.exceptions.TypeError("math.isqrt only supports integers.");
+        if (n instanceof org.python.types.Int) {
+            long n_val = ((org.python.types.Int) n.__int__()).value;
+            if (n_val < 0) {
+                throw new org.python.exceptions.ValueError("isqrt() argument must be nonnegative");
+            }
+            return org.python.types.Int.getInt(((long) Math.floor(Math.sqrt(n_val))));
+        }
+        throw new org.python.exceptions.TypeError("'" + n.typeName() + "' object cannot be interpreted as an integer");
     }
 
 }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,13 +1,17 @@
 package python;
 
-import java.lang.Math;
+@org.python.Module(
+        __doc__ =
+        "This module provides access to the mathematical functions defined by the C standard.\n"
+        + "\n"
+        + "These functions cannot be used with complex numbers; use the functions of the same\n"
+        + "name from the cmath module if you require support for complex numbers.\n"
+        + "The distinction between functions which support complex numbers and those which don’t\n"
+        + "is made since most users do not want to learn quite as much mathematics as required\n"
+        + "to understand complex numbers. Receiving an exception instead of a complex result\n"
+        + "allows earlier detection of the unexpected complex number used as a parameter,\n"
+        + "so that the programmer can determine how and why it was generated in the first place.")
 
-@org.python.Module(__doc__ = "This module provides access to the mathematical functions defined by the C standard.\n"+
-"These functions cannot be used with complex numbers; use the functions of the same name from the cmath module if you require support for complex numbers.\n"+
-"The distinction between functions which support complex numbers and those which don’t\n"+
-"is made since most users do not want to learn quite as much mathematics as required to understand complex numbers\n."+ 
-"Receiving an exception instead of a complex result allows earlier detection of the unexpected complex number used as a parameter,\n"+ 
-"so that the programmer can determine how and why it was generated in the first place.")
 public class math extends org.python.types.Module {
     public math() {
         super();
@@ -17,12 +21,12 @@ public class math extends org.python.types.Module {
     public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");
     @org.python.Attribute
     public static org.python.Object __name__ = new org.python.types.Str("math");
-   
+
 
     @org.python.Method(__doc__ = "isqrt(n) -> int\n\n"
             + "Return the integer square root of the nonnegative integer n.\n"
             + "This is the floor of the exact square root of n\n"
-            + "or equivalently the greatest integer a such that a² ≤ n.", 
+            + "or equivalently the greatest integer a such that a² ≤ n.",
             args = { "n" })
     public static org.python.Object isqrt(org.python.Object n) {
         if (n instanceof org.python.types.Int) {
@@ -34,5 +38,4 @@ public class math extends org.python.types.Module {
         }
         throw new org.python.exceptions.TypeError("'" + n.typeName() + "' object cannot be interpreted as an integer");
     }
-
 }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -2,15 +2,8 @@ package python;
 
 @org.python.Module(
         __doc__ =
-        "This module provides access to the mathematical functions defined by the C standard.\n"
-        + "\n"
-        + "These functions cannot be used with complex numbers; use the functions of the same\n"
-        + "name from the cmath module if you require support for complex numbers.\n"
-        + "The distinction between functions which support complex numbers and those which don’t\n"
-        + "is made since most users do not want to learn quite as much mathematics as required\n"
-        + "to understand complex numbers. Receiving an exception instead of a complex result\n"
-        + "allows earlier detection of the unexpected complex number used as a parameter,\n"
-        + "so that the programmer can determine how and why it was generated in the first place.")
+        "This module provides access to the mathematical functions\n"
+        + "defined by the C standard.")
 
 public class math extends org.python.types.Module {
     public math() {
@@ -24,9 +17,7 @@ public class math extends org.python.types.Module {
 
 
     @org.python.Method(__doc__ = "isqrt(n) -> int\n\n"
-            + "Return the integer square root of the nonnegative integer n.\n"
-            + "This is the floor of the exact square root of n\n"
-            + "or equivalently the greatest integer a such that a² ≤ n.",
+            + "Return the integer part of the square root of the input.",
             args = { "n" })
     public static org.python.Object isqrt(org.python.Object n) {
         if (n instanceof org.python.types.Int) {

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,0 +1,40 @@
+package python;
+import java.lang.Math;
+
+@org.python.Module(
+        __doc__ =
+                "TODO: Write me!"
+)
+public class math extends org.python.types.Module {
+    public math() {
+        super();
+    }
+
+
+    @org.python.Attribute
+    public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");
+    // @org.python.Attribute
+    // public static org.python.Object __loader__ = org.python.types.NoneType.NONE;
+    @org.python.Attribute
+    public static org.python.Object __name__ = new org.python.types.Str("math");
+    // @org.python.Attribute
+    // public static org.python.Object __package__ = new org.python.types.Str("");
+    // @org.python.Attribute
+    // public static org.python.Object __spec__ = org.python.types.NoneType.NONE;
+
+    @org.python.Method(
+         __doc__ = "Return the integer square root of the nonnegative integer n. This is the floor of the exact square root of n, or equivalently the greatest integer a such that a² ≤ n.",
+         args = {"n"}
+    )
+    public static org.python.Object isqrt(org.python.Object n) {
+       if (n instanceof org.python.types.Int) {
+           long n_val = ((org.python.types.Int) n.__int__()).value;
+           if (n_val < 0) {
+             throw new org.python.exceptions.ValueError("math.isqrt only supports nonnegative integers.");
+           }
+           return org.python.types.Int.getInt(((long) Math.floor(Math.sqrt(n_val))));
+       }
+       throw new org.python.exceptions.TypeError("math.isqrt only supports integers.");
+    }
+
+}

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -5,6 +5,14 @@ from ..utils import TranspileTestCase
 class MathModuleTests(TranspileTestCase):
 
     #######################################################
+    # __doc__
+    def test_math___doc__(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.__doc__)
+            """)
+
+    #######################################################
     # isqrt
     @expectedFailure
     def test_isqrt_string(self):

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -42,7 +42,7 @@ class MathModuleTests(TranspileTestCase):
             """)
 
     @expectedFailure
-    def test_isqrt_positve_float(self):
+    def test_isqrt_positive_float(self):
         self.assertCodeExecution("""
             import math
             math.isqrt(5.8)
@@ -51,11 +51,11 @@ class MathModuleTests(TranspileTestCase):
     def test_isqrt_possible_outcomes(self):
         self.assertCodeExecution("""
             import math
-            math.isqrt(5)
-            math.isqrt(16)
-            math.isqrt(0)
-            math.isqrt(1)
-            math.isqrt(20129310)
+            print(math.isqrt(5))
+            print(math.isqrt(16))
+            print(math.isqrt(0))
+            print(math.isqrt(1))
+            print(math.isqrt(20129310))
             try:
                 math.isqrt("hej")
             except Exception as e:

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -1,10 +1,9 @@
-import math
 from unittest import expectedFailure
 from ..utils import TranspileTestCase
 
 
 class MathModuleTests(TranspileTestCase):
-    
+
     #######################################################
     # isqrt
     @expectedFailure

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -1,0 +1,84 @@
+import math
+from unittest import expectedFailure
+from ..utils import TranspileTestCase
+
+
+class MathModuleTests(TranspileTestCase):
+    
+    #######################################################
+    # isqrt
+    @expectedFailure
+    def test_isqrt_string(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt('hej')
+            """)
+
+    @expectedFailure
+    def test_isqrt_empty(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt()
+            """)
+
+    @expectedFailure
+    def test_isqrt_none(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt(None)
+            """)
+
+    @expectedFailure
+    def test_isqrt_negative_int(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt(-5)
+            """)
+
+    @expectedFailure
+    def test_isqrt_negative_float(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt(-5.8)
+            """)
+
+    @expectedFailure
+    def test_isqrt_positve_float(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt(5.8)
+            """)
+
+    def test_isqrt_possible_outcomes(self):
+        self.assertCodeExecution("""
+            import math
+            math.isqrt(5)
+            math.isqrt(16)
+            math.isqrt(0)
+            math.isqrt(1)
+            math.isqrt(20129310)
+            try:
+                math.isqrt("hej")
+            except Exception as e:
+                print(e)
+            try:
+                math.isqrt(5.5)
+            except Exception as e:
+                print(e)
+            try:
+                math.isqrt([123,52])
+            except Exception as e:
+                print(e)
+            try:
+                math.isqrt(None)
+            except Exception as e:
+                print(e)
+            try:
+                math.isqrt(-5)
+            except Exception as e:
+                print(e)
+            try:
+                math.isqrt((5,2,3))
+            except Exception as e:
+                print(e)
+            """)


### PR DESCRIPTION
Implements the `math.isqrt` method from Python's standard library.

Tested on Python 3.8.0 with Java OpenJDK 1.8.0_192, and Python 3.9.5 with Java HotSpot 16.0.2.
