### PR TITLE
Implement math.ceil stdlib method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tests/tmp*
 .DS_Store
 .idea/
 .vscode
+/env

--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -160,7 +160,6 @@ public interface Object extends Comparable {
     public org.python.Object __pos__();
     public org.python.Object __abs__();
     public org.python.Object __invert__();
-    public org.python.Object __ceil__();
 
     public org.python.Object __not__();
 

--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -160,6 +160,7 @@ public interface Object extends Comparable {
     public org.python.Object __pos__();
     public org.python.Object __abs__();
     public org.python.Object __invert__();
+    public org.python.Object __ceil__();
 
     public org.python.Object __not__();
 

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -610,6 +610,13 @@ public class Float extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "ceil(self)"
+    )
+    public org.python.Object __ceil__() {
+        return new org.python.types.Float(Math.ceil(this.value));
+    }
+
+    @org.python.Method(
             __doc__ = "int(self)"
     )
     public org.python.Object __int__() {

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -613,7 +613,8 @@ public class Float extends org.python.types.Object {
             __doc__ = "ceil(self)"
     )
     public org.python.Object __ceil__() {
-        return new org.python.types.Float(Math.ceil(this.value));
+        int result = (int) Math.ceil(this.value);
+        return org.python.types.Int.getInt(result);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -881,6 +881,13 @@ public class Int extends org.python.types.Object {
     }
 
     @org.python.Method(
+        __doc__ = "ceil(self)"
+    )
+    public org.python.Object __ceil__() {
+        return this;
+    }
+
+    @org.python.Method(
             __doc__ = "~self"
     )
     public org.python.Object __invert__() {

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -881,7 +881,7 @@ public class Int extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = "ceil(self)"
+            __doc__ = "ceil(self)"
     )
     public org.python.Object __ceil__() {
         return this;
@@ -921,8 +921,9 @@ public class Int extends org.python.types.Object {
                 return this;
             } else {
                 long half_pow = 5;
-                for (long i = 1; i < -_ndigits; i++)
+                for (long i = 1; i < -_ndigits; i++) {
                     half_pow *= 10;
+                }
                 long remainder = this.value % (half_pow * 4);
 
                 if (remainder >= half_pow * 3) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -969,6 +969,13 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     @org.python.Method(
             __doc__ = ""
     )
+    public org.python.Object __ceil__() {
+        throw new org.python.exceptions.TypeError("must be real number, not '" + this.typeName() + "'");
+    }
+
+    @org.python.Method(
+            __doc__ = ""
+    )
     public org.python.Object __not__() {
         return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__bool__()).value);
     }

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -970,7 +970,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             __doc__ = ""
     )
     public org.python.Object __ceil__() {
-        throw new org.python.exceptions.TypeError("must be real number, not '" + this.typeName() + "'");
+        throw new org.python.exceptions.AttributeError(this, "__ceil__");
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -850,6 +850,13 @@ public class Super implements org.python.Object {
     @org.python.Method(
             __doc__ = ""
     )
+    public org.python.Object __ceil__() {
+        throw new org.python.exceptions.TypeError("must be real number, not '" + this.typeName() + "'");
+    }
+
+    @org.python.Method(
+            __doc__ = ""
+    )
     public org.python.Object __not__() {
         return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__bool__()).value);
     }

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -851,7 +851,7 @@ public class Super implements org.python.Object {
             __doc__ = ""
     )
     public org.python.Object __ceil__() {
-        throw new org.python.exceptions.TypeError("must be real number, not '" + this.typeName() + "'");
+        throw new org.python.exceptions.AttributeError(this, "__ceil__");
     }
 
     @org.python.Method(

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,0 +1,20 @@
+package python;
+
+@org.python.Module(__doc__ = "")
+public class math extends org.python.types.Module {
+    @org.python.Attribute
+    public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");
+    @org.python.Attribute
+    public static org.python.Object __loader__ = org.python.types.NoneType.NONE; // TODO
+    @org.python.Attribute
+    public static org.python.Object __name__ = new org.python.types.Str("time");
+    @org.python.Attribute
+    public static org.python.Object __package__ = new org.python.types.Str("");
+    @org.python.Attribute
+    public static org.python.Object __spec__ = org.python.types.NoneType.NONE; // TODO
+
+    @org.python.Method(__doc__ = "")
+    public static org.python.Object ceil(org.python.Object number) {
+        throw new org.python.exceptions.NotImplementedError("math.ceil() has not been implemented.");
+    }
+}

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -13,8 +13,13 @@ public class math extends org.python.types.Module {
     @org.python.Attribute
     public static org.python.Object __spec__ = org.python.types.NoneType.NONE; // TODO
 
-    @org.python.Method(__doc__ = "")
-    public static org.python.Object ceil(org.python.Object number) {
-        throw new org.python.exceptions.NotImplementedError("math.ceil() has not been implemented.");
+    @org.python.Method(__doc__ = "ceil(x) -> number\n\n"
+            + "Return the ceiling of x as an Integral.\n\nThis is the smallest integer >= x.")
+    public static org.python.Object ceil(org.python.Object x) {
+        try {
+            return x.__ceil__();
+        } catch (org.python.exceptions.AttributeError ae) {
+            throw new org.python.exceptions.TypeError("must be real number, not '" + x.typeName() + "'");
+        }
     }
 }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -5,20 +5,18 @@ public class math extends org.python.types.Module {
     @org.python.Attribute
     public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");
     @org.python.Attribute
-    public static org.python.Object __loader__ = org.python.types.NoneType.NONE; // TODO
-    @org.python.Attribute
-    public static org.python.Object __name__ = new org.python.types.Str("time");
-    @org.python.Attribute
-    public static org.python.Object __package__ = new org.python.types.Str("");
-    @org.python.Attribute
-    public static org.python.Object __spec__ = org.python.types.NoneType.NONE; // TODO
+    public static org.python.Object __package__ = new org.python.types.Str("math");
 
     @org.python.Method(__doc__ = "ceil(x) -> number\n\n"
-            + "Return the ceiling of x as an Integral.\n\nThis is the smallest integer >= x.")
+            + "Return the ceiling of x as an Integral.\n\nThis is the smallest integer >= x.", args = { "x" })
     public static org.python.Object ceil(org.python.Object x) {
-        try {
-            return x.__ceil__();
-        } catch (org.python.exceptions.AttributeError ae) {
+        if (x instanceof org.python.types.Float) {
+            org.python.types.Float number = (org.python.types.Float) x;
+            return number.__ceil__();
+        } else if (x instanceof org.python.types.Int) {
+            org.python.types.Int number = (org.python.types.Int) x;
+            return number.__ceil__();
+        } else {
             throw new org.python.exceptions.TypeError("must be real number, not '" + x.typeName() + "'");
         }
     }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -10,6 +10,10 @@ public class math extends org.python.types.Module {
     @org.python.Method(__doc__ = "ceil(x) -> number\n\n"
             + "Return the ceiling of x as an Integral.\n\nThis is the smallest integer >= x.", args = { "x" })
     public static org.python.Object ceil(org.python.Object x) {
-        return x.__ceil__();
+        try {
+            return x.__ceil__();
+        } catch (org.python.exceptions.AttributeError ae) {
+            throw new org.python.exceptions.TypeError("must be real number, not " + x.typeName());
+        }
     }
 }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -10,14 +10,6 @@ public class math extends org.python.types.Module {
     @org.python.Method(__doc__ = "ceil(x) -> number\n\n"
             + "Return the ceiling of x as an Integral.\n\nThis is the smallest integer >= x.", args = { "x" })
     public static org.python.Object ceil(org.python.Object x) {
-        if (x instanceof org.python.types.Float) {
-            org.python.types.Float number = (org.python.types.Float) x;
-            return number.__ceil__();
-        } else if (x instanceof org.python.types.Int) {
-            org.python.types.Int number = (org.python.types.Int) x;
-            return number.__ceil__();
-        } else {
-            throw new org.python.exceptions.TypeError("must be real number, not '" + x.typeName() + "'");
-        }
+        return x.__ceil__();
     }
 }

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,6 +1,6 @@
 package python;
 
-@org.python.Module(__doc__ = "")
+@org.python.Module(__doc__ = "This module provides access to the mathematical functions\ndefined by the C standard.")
 public class math extends org.python.types.Module {
     @org.python.Attribute
     public static org.python.Object __file__ = new org.python.types.Str("python/common/python/math.java");

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -11,9 +11,9 @@ class MathModuleTests(TranspileTestCase):
             import math
             print(math.__doc__)
             """)
+
     ############################################################
     # ceil
-
     def test_ceil_float(self):
         self.assertCodeExecution("""
             import math

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -5,9 +5,44 @@ from ..utils import TranspileTestCase
 class MathModuleTests(TranspileTestCase):
 
     ############################################################
+    # __doc__
+    def test___doc__(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.__doc__)
+            """)
+    ############################################################
     # ceil
+
     def test_ceil_float(self):
         self.assertCodeExecution("""
             import math
             print(math.ceil(3.5))
+            """)
+
+    def test_ceil_int(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil(3))
+            """)
+
+    @expectedFailure
+    def test_ceil_no_args(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil())
+            """)
+
+    @expectedFailure
+    def test_ceil_multiple_args(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil(1.5, 2))
+            """)
+
+    @expectedFailure
+    def test_ceil_string(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil("test"))
             """)

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -9,28 +9,8 @@ class MathModuleTests(TranspileTestCase):
 
     ############################################################
     # ceil
-    @expectedFailure
-    def test_ceil_no_args(self):
-        self.assertCodeExecution("""
-            import math
-            print(math.ceil())
-            """)
-
-    @expectedFailure
-    def test_ceil_string(self):
-        self.assertCodeExecution("""
-            import math
-            print(math.ceil("test"))
-            """)
-
     def test_ceil_float(self):
         self.assertCodeExecution("""
             import math
             print(math.ceil(3.5))
-            """)
-
-    def test_ceil_float(self):
-        self.assertCodeExecution("""
-            import math
-            print(math.ceil(3))
             """)

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -46,3 +46,14 @@ class MathModuleTests(TranspileTestCase):
             import math
             print(math.ceil("test"))
             """)
+
+    def test_ceil_override(self):
+        self.assertCodeExecution("""
+        import math
+        class Test:
+            number = 3.5
+            def __ceil__(self):
+                return math.ceil(self.number)
+        test = Test()
+        print(math.ceil(test))
+        """)

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -1,0 +1,36 @@
+import math
+
+from unittest import expectedFailure
+
+from ..utils import TranspileTestCase
+
+
+class MathModuleTests(TranspileTestCase):
+
+    ############################################################
+    # ceil
+    @expectedFailure
+    def test_ceil_no_args(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil())
+            """)
+
+    @expectedFailure
+    def test_ceil_string(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil("test"))
+            """)
+
+    def test_ceil_float(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil(3.5))
+            """)
+
+    def test_ceil_float(self):
+        self.assertCodeExecution("""
+            import math
+            print(math.ceil(3))
+            """)

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -1,7 +1,4 @@
-import math
-
 from unittest import expectedFailure
-
 from ..utils import TranspileTestCase
 
 

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -57,3 +57,21 @@ class MathModuleTests(TranspileTestCase):
         test = Test()
         print(math.ceil(test))
         """)
+
+    def test_ceil_exception_msg(self):
+        self.assertCodeExecution("""
+        import math
+        try:
+            math.ceil("str")
+        except Exception as e:
+            print(e)
+        """)
+
+    def test_ceil_exception_msg2(self):
+        self.assertCodeExecution("""
+        import math
+        try:
+            ("str").__ceil__()
+        except Exception as e:
+            print(e)
+        """)


### PR DESCRIPTION
Implements the `math.ceil` method from Python's standard library.
Tested on Python 3.9.4 with Java OpenJDK 1.8.0_302.