### PR TITLE
Partial implementation of Python's stdlib `datetime.date`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ tests/tmp*
 .idea/
 .vscode
 /env
+/out
+*.iml

--- a/build.xml
+++ b/build.xml
@@ -31,6 +31,7 @@
     <checkstyle config="checkstyle.xml" failureProperty="checkstyle.failure.property">
       <formatter type="plain" />
       <fileset dir="python" includes="**/*.java" />
+      <fileset dir="junit" includes="**/*.java" />
     </checkstyle>
   </target>
 

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -1,0 +1,113 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.python.stdlib.datetime.Date;
+
+import java.util.Collections;
+
+
+
+public class DateTest {
+    public org.python.Object[] createArgs(long year, long month, long day) {
+        org.python.types.Int d = org.python.types.Int.getInt(day);
+        org.python.types.Int m = org.python.types.Int.getInt(month);
+        org.python.types.Int y = org.python.types.Int.getInt(year);
+        org.python.Object[] args = {y, m, d};
+        return args;
+    }
+
+
+    public Date createDate(long year, long month, long day) {
+        org.python.types.Int d = org.python.types.Int.getInt(day);
+        org.python.types.Int m = org.python.types.Int.getInt(month);
+        org.python.types.Int y = org.python.types.Int.getInt(year);
+        org.python.Object[] args = {y, m, d};
+        return new Date(args, Collections.emptyMap());
+    }
+
+    @Test
+    public void testDateConstructorSuccess1() {
+        // Only args used.
+        org.python.types.Int y = org.python.types.Int.getInt(2021);
+        org.python.types.Int m = org.python.types.Int.getInt(9);
+        org.python.types.Int d = org.python.types.Int.getInt(14);
+        org.python.Object[] args = {y, m, d};
+        java.util.Map<java.lang.String, org.python.Object> kwargs = Collections.emptyMap();
+        assertDoesNotThrow(() -> new Date(args, kwargs));
+    }
+
+    @Test
+    public void testDateConstructorSuccess2() {
+        // Mixed usage of kwargs and args.
+        org.python.types.Int y = org.python.types.Int.getInt(2021);
+        org.python.types.Int m = org.python.types.Int.getInt(9);
+        org.python.Object[] args = {y, m};
+        java.util.Map<java.lang.String, org.python.Object> kwargs = new java.util.HashMap<java.lang.String, org.python.Object>() {
+            {
+                put("day", org.python.types.Int.getInt(2));
+            }
+        };
+        assertDoesNotThrow(() -> new Date(args, kwargs));
+    }
+
+    @Test
+    public void testDateConstructorSuccess3() {
+        // Only kwargs used.
+        org.python.Object[] args = {};
+        java.util.Map<java.lang.String, org.python.Object> kwargs = new java.util.HashMap<java.lang.String, org.python.Object>() {
+            {
+                put("year", org.python.types.Int.getInt(2021));
+                put("month", org.python.types.Int.getInt(9));
+                put("day", org.python.types.Int.getInt(14));
+            }
+        };
+        assertDoesNotThrow(() -> new Date(args, kwargs));
+    }
+
+    @Test
+    public void test__repr__() {
+        Date d = createDate(2021, 9, 14);
+        assertEquals("datetime.date(2021, 9, 14)", d.__repr__().value);
+    }
+
+    @Test
+    public void testYearMonthDay() {
+        Date d = createDate(2021, 9, 14);
+        assertEquals(org.python.types.Int.getInt(2021), d.year);
+        assertEquals(org.python.types.Int.getInt(9), d.month);
+        assertEquals(org.python.types.Int.getInt(14), d.day);
+    }
+
+    @Test
+    public void testMax() {
+        Date d = createDate(python.datetime.MAXYEAR.value, 12, 31);
+        assertEquals(d, Date.max);
+    }
+
+    @Test
+    public void testMin() {
+        Date d = createDate(python.datetime.MINYEAR.value, 1, 1);
+        assertEquals(d, Date.min);
+    }
+
+    @Test
+    public void testToday() {
+        java.time.LocalDateTime expected = java.time.LocalDateTime.now();
+        Date actual = (Date) Date.today();
+        assertEquals(org.python.types.Int.getInt(expected.getYear()), actual.year);
+        assertEquals(org.python.types.Int.getInt(expected.getMonthValue()), actual.month);
+        assertEquals(org.python.types.Int.getInt(expected.getDayOfMonth()), actual.day);
+    }
+
+    @Test
+    public void testCtime() {
+        Date d = createDate(2021, 9, 14);
+        assertEquals("Tue Sep 14 00:00:00 2021", ((org.python.types.Str) d.ctime()).value);
+    }
+
+    @Test
+    public void testWeekday() {
+        Date d = createDate(2021, 9, 14);
+        assertEquals(1, ((org.python.types.Int) d.weekday()).value);
+    }
+}

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -116,6 +116,16 @@ public class DateTest {
     }
 
     @Test
+    public void testDateConstructorOutOfRangeException() {
+        org.python.types.Int year = org.python.types.Int.getInt(2010);
+        org.python.types.Int month = org.python.types.Int.getInt(1);
+        org.python.types.Int day = org.python.types.Int.getInt(35);
+        org.python.Object[] args = {year, month, day};
+        Exception exception = assertThrows(org.python.exceptions.ValueError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("day is out of range for month", exception.getMessage());
+    }
+
+    @Test
     public void testDateConstructor4argsException() {
         org.python.types.Int num = org.python.types.Int.getInt(1);
         org.python.Object[] args = {num, num, num, num};

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -1,11 +1,14 @@
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.python.stdlib.datetime.Date;
 
 import java.util.Collections;
-
-
+import java.util.HashMap;
+import java.util.Map;
 
 public class DateTest {
     public org.python.Object[] createArgs(long year, long month, long day) {
@@ -109,5 +112,61 @@ public class DateTest {
     public void testWeekday() {
         Date d = createDate(2021, 9, 14);
         assertEquals(1, ((org.python.types.Int) d.weekday()).value);
+    }
+
+    @Test
+    public void testDateConstructor4argsException() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.Object[] args = {num, num, num, num};
+        Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("function takes at most 3 arguments (4 given)", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructor3argsException() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.Object[] args = {num, num};
+        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {{
+            put("year", num);
+        }};
+        Exception exception = assertThrows(org.python.exceptions.SyntaxError.class, () -> new Date(args, kwargs));
+        assertEquals("positional argument follows keyword argument", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructor3argsException2() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.types.Str str = new org.python.types.Str("test");
+        org.python.Object[] args = {num, num, str};
+        Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("an integer is required (got type str)", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructor2argsException() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.types.Str str = new org.python.types.Str("test");
+        org.python.Object[] args = {str, num};
+        Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("an integer is required (got type str)", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructor2argsException2() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.Object[] args = {num, num};
+        Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("function missing required argument 'day' (pos 3)", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructor1argsException() {
+        org.python.types.Int num = org.python.types.Int.getInt(1);
+        org.python.Object[] args = {};
+        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {{
+            put("month", num);
+        }};
+        Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, kwargs));
+        assertEquals("function missing required argument 'year' (pos 1)", exception.getMessage());
     }
 }

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -70,6 +70,20 @@ public class DateTest {
     }
 
     @Test
+    public void testDateConstructorSuccess4() {
+        // Leap year.
+        org.python.Object[] args = {};
+        java.util.Map<java.lang.String, org.python.Object> kwargs = new java.util.HashMap<java.lang.String, org.python.Object>() {
+            {
+                put("year", org.python.types.Int.getInt(2020));
+                put("month", org.python.types.Int.getInt(2));
+                put("day", org.python.types.Int.getInt(29));
+            }
+        };
+        assertDoesNotThrow(() -> new Date(args, kwargs));
+    }
+
+    @Test
     public void test__repr__() {
         Date d = createDate(2021, 9, 14);
         assertEquals("datetime.date(2021, 9, 14)", d.__repr__().value);
@@ -117,10 +131,30 @@ public class DateTest {
     }
 
     @Test
-    public void testDateConstructorOutOfRangeException() {
+    public void testDateConstructorOutOfRangeException1() {
         org.python.types.Int year = org.python.types.Int.getInt(2010);
         org.python.types.Int month = org.python.types.Int.getInt(1);
         org.python.types.Int day = org.python.types.Int.getInt(35);
+        org.python.Object[] args = {year, month, day};
+        Exception exception = assertThrows(org.python.exceptions.ValueError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("day is out of range for month", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructorOutOfRangeException2() {
+        org.python.types.Int year = org.python.types.Int.getInt(2021);
+        org.python.types.Int month = org.python.types.Int.getInt(2);
+        org.python.types.Int day = org.python.types.Int.getInt(29);
+        org.python.Object[] args = {year, month, day};
+        Exception exception = assertThrows(org.python.exceptions.ValueError.class, () -> new Date(args, Collections.emptyMap()));
+        assertEquals("day is out of range for month", exception.getMessage());
+    }
+
+    @Test
+    public void testDateConstructorOutOfRangeException3() {
+        org.python.types.Int year = org.python.types.Int.getInt(2021);
+        org.python.types.Int month = org.python.types.Int.getInt(4);
+        org.python.types.Int day = org.python.types.Int.getInt(31);
         org.python.Object[] args = {year, month, day};
         Exception exception = assertThrows(org.python.exceptions.ValueError.class, () -> new Date(args, Collections.emptyMap()));
         assertEquals("day is out of range for month", exception.getMessage());

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -252,4 +252,55 @@ public class DateTest {
         assertFalse(((org.python.types.Bool) d2021_9_14.__gt__(d2021_9_14_same)).value);
         assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__gt__(org.python.types.Int.getInt(1)));
     }
+
+    @Test
+    public void testIsoformat() {
+        Date d1_1_1 = createDate(1, 1, 1);
+        Date d2021_9_15 = createDate(2021, 9, 15);
+        assertEquals("0001-01-01", ((org.python.types.Str) d1_1_1.isoformat()).value);
+        assertEquals("2021-09-15", ((org.python.types.Str) d2021_9_15.isoformat()).value);
+    }
+
+    @Test
+    public void testFromIsoformat() {
+        Date d1_1_1 = createDate(1, 1, 1);
+        org.python.types.Str s1_1_1 = new org.python.types.Str("0001-01-01");
+        Date d2021_9_15 = createDate(2021, 9, 15);
+        org.python.types.Str s2021_9_15 = new org.python.types.Str("2021-09-15");
+        assertTrue(((org.python.types.Bool) d1_1_1.__eq__(Date.fromisoformat(s1_1_1))).value);
+        assertTrue(((org.python.types.Bool) d2021_9_15.__eq__(Date.fromisoformat(s2021_9_15))).value);
+    }
+
+    @Test
+    public void testFromIsoformatBadString() {
+        org.python.types.Str bad1 = new org.python.types.Str("1-1-1");
+        org.python.types.Str bad2 = new org.python.types.Str("20b1-12-01");
+        org.python.types.Str bad3 = new org.python.types.Str("sdfgsaldkuhad");
+        org.python.types.Str bad4 = new org.python.types.Str("viek-eg-xb");
+        org.python.types.Str bad5 = new org.python.types.Str("");
+        org.python.types.Str bad6 = new org.python.types.Str("202\n-12-01");
+        org.python.types.Str bad7 = new org.python.types.Str("-200-12-01");
+        Exception exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad1));
+        assertEquals("Invalid isoformat string: '" + bad1 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad2));
+        assertEquals("Invalid isoformat string: '" + bad2 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad3));
+        assertEquals("Invalid isoformat string: '" + bad3 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad4));
+        assertEquals("Invalid isoformat string: '" + bad4 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad5));
+        assertEquals("Invalid isoformat string: '" + bad5 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad6));
+        assertEquals("Invalid isoformat string: '" + bad6 + "'", exception.getMessage());
+        exception = assertThrows(org.python.exceptions.ValueError.class, () -> Date.fromisoformat(bad7));
+        assertEquals("Invalid isoformat string: '" + bad7 + "'", exception.getMessage());
+    }
+
+    @Test
+    public void testIsoformatInverse() {
+        org.python.types.Str s1_2_3 = new org.python.types.Str("0001-02-03");
+        org.python.types.Str s2020_6_12 = new org.python.types.Str("2020-06-12");
+        assertEquals(s1_2_3.value, ((org.python.types.Str) ((Date) Date.fromisoformat(s1_2_3)).isoformat()).value);
+        assertEquals(s2020_6_12.value, ((org.python.types.Str) ((Date) Date.fromisoformat(s2020_6_12)).isoformat()).value);
+    }
 }

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -85,6 +85,7 @@ public class DateTest {
     public void testMax() {
         Date d = createDate(python.datetime.MAXYEAR.value, 12, 31);
         assertEquals(d, Date.max);
+        //assertTrue(d.__eq__(Date.max));
     }
 
     @Test

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -86,14 +86,13 @@ public class DateTest {
     @Test
     public void testMax() {
         Date d = createDate(python.datetime.MAXYEAR.value, 12, 31);
-        assertEquals(d, Date.max);
-        //assertTrue(d.__eq__(Date.max));
+        assertTrue(((org.python.types.Bool) d.__eq__(Date.max)).value);
     }
 
     @Test
     public void testMin() {
         Date d = createDate(python.datetime.MINYEAR.value, 1, 1);
-        assertEquals(d, Date.min);
+        assertTrue(((org.python.types.Bool) d.__eq__(Date.min)).value);
     }
 
     @Test

--- a/junit/DateTest.java
+++ b/junit/DateTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.python.stdlib.datetime.Date;
 
@@ -137,9 +139,11 @@ public class DateTest {
     public void testDateConstructor3argsException() {
         org.python.types.Int num = org.python.types.Int.getInt(1);
         org.python.Object[] args = {num, num};
-        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {{
-            put("year", num);
-        }};
+        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {
+            {
+                put("year", num);
+            }
+        };
         Exception exception = assertThrows(org.python.exceptions.SyntaxError.class, () -> new Date(args, kwargs));
         assertEquals("positional argument follows keyword argument", exception.getMessage());
     }
@@ -174,10 +178,78 @@ public class DateTest {
     public void testDateConstructor1argsException() {
         org.python.types.Int num = org.python.types.Int.getInt(1);
         org.python.Object[] args = {};
-        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {{
-            put("month", num);
-        }};
+        Map<String, org.python.Object> kwargs = new HashMap<String, org.python.Object>() {
+            {
+                put("month", num);
+            }
+        };
         Exception exception = assertThrows(org.python.exceptions.TypeError.class, () -> new Date(args, kwargs));
         assertEquals("function missing required argument 'year' (pos 1)", exception.getMessage());
+    }
+
+    @Test
+    public void testComparisonOperators() {
+        Date d2018_8_1 = createDate(2018, 8, 1);
+        Date d2018_12_31 = createDate(2018, 12, 31);
+        Date d2021_7_21 = createDate(2021, 7, 21);
+        Date d2021_9_14 = createDate(2021, 9, 14);
+        Date d2021_9_15 = createDate(2021, 9, 15);
+        Date d2022_4_28 = createDate(2022, 4, 28);
+
+        Date d2021_9_14_same = createDate(2021, 9, 14);
+
+        // __lt__
+        assertTrue(((org.python.types.Bool) d2021_9_14.__lt__(d2022_4_28)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__lt__(d2021_9_15)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__lt__(d2018_8_1)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__lt__(d2018_12_31)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__lt__(d2021_7_21)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__lt__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__lt__(org.python.types.Int.getInt(1)));
+
+        // __le__
+        assertTrue(((org.python.types.Bool) d2021_9_14.__le__(d2022_4_28)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__le__(d2021_9_15)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__le__(d2018_8_1)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__le__(d2018_12_31)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__le__(d2021_7_21)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__le__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__le__(org.python.types.Int.getInt(1)));
+
+        // __eq__
+        assertFalse(((org.python.types.Bool) d2021_9_14.__eq__(d2022_4_28)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__eq__(d2021_9_15)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__eq__(d2018_8_1)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__eq__(d2018_12_31)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__eq__(d2021_7_21)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__eq__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__eq__(org.python.types.Int.getInt(1)));
+
+        // __ne__
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ne__(d2022_4_28)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ne__(d2021_9_15)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ne__(d2018_8_1)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ne__(d2018_12_31)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ne__(d2021_7_21)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__ne__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__ne__(org.python.types.Int.getInt(1)));
+
+        // __ge__
+        assertFalse(((org.python.types.Bool) d2021_9_14.__ge__(d2022_4_28)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__ge__(d2021_9_15)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ge__(d2018_8_1)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ge__(d2018_12_31)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ge__(d2021_7_21)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__ge__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__ge__(org.python.types.Int.getInt(1)));
+
+        // __gt__
+        assertFalse(((org.python.types.Bool) d2021_9_14.__gt__(d2022_4_28)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__gt__(d2021_9_15)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__gt__(d2018_8_1)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__gt__(d2018_12_31)).value);
+        assertTrue(((org.python.types.Bool) d2021_9_14.__gt__(d2021_7_21)).value);
+        assertFalse(((org.python.types.Bool) d2021_9_14.__gt__(d2021_9_14_same)).value);
+        assertEquals(org.python.types.NotImplementedType.NOT_IMPLEMENTED, d2021_9_14.__gt__(org.python.types.Int.getInt(1)));
     }
 }

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -248,4 +248,90 @@ public class Date extends org.python.types.Object {
         int[] convertToPython = {6, 0, 1, 2, 3, 4, 5};
         return org.python.types.Int.getInt(convertToPython[day - 1]);
     }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __lt__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = this._lessThan((Date) other);
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __le__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = this._lessThan((Date) other)
+                    || this._equals((Date) other);
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __eq__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = this._equals((Date) other);
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __ne__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = !(this._equals((Date) other));
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __ge__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = !(this._lessThan((Date) other));
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object __gt__(org.python.Object other) {
+        if (other instanceof Date) {
+            boolean res = !(this._lessThan((Date) other))
+                    && !(this._equals((Date) other));
+            return org.python.types.Bool.getBool(res);
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
+    private boolean _equals(Date other) {
+        long y1 = ((org.python.types.Int) this.year).value;
+        long m1 = ((org.python.types.Int) this.month).value;
+        long d1 = ((org.python.types.Int) this.day).value;
+        long y2 = ((org.python.types.Int) other.year).value;
+        long m2 = ((org.python.types.Int) other.month).value;
+        long d2 = ((org.python.types.Int) other.day).value;
+
+        return y1 == y2 && m1 == m2 && d1 == d2;
+    }
+
+    private boolean _lessThan(Date other) {
+        long y1 = ((org.python.types.Int) this.year).value;
+        long m1 = ((org.python.types.Int) this.month).value;
+        long d1 = ((org.python.types.Int) this.day).value;
+        long y2 = ((org.python.types.Int) other.year).value;
+        long m2 = ((org.python.types.Int) other.month).value;
+        long d2 = ((org.python.types.Int) other.day).value;
+
+        return y1 < y2
+            || (y1 == y2 && m1 < m2)
+            || (y1 == y2 && m1 == m2 && d1 < d2);
+    }
 }

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -54,7 +54,7 @@ public class Date extends org.python.types.Object {
             }
 
             if ((this.year instanceof org.python.types.Int) && (this.month instanceof org.python.types.Int) && (this.day instanceof org.python.types.Int)) {
-                if (1 <= ((org.python.types.Int) this.year).value && ((org.python.types.Int) this.year).value <= 999) {
+                if (python.datetime.MINYEAR.value <= ((org.python.types.Int) this.year).value && ((org.python.types.Int) this.year).value <= python.datetime.MAXYEAR.value) {
 
                     if (1d <= ((org.python.types.Int) this.month).value && ((org.python.types.Int) this.month).value <= 12d) {
                         if (1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= 31d) {
@@ -149,7 +149,6 @@ public class Date extends org.python.types.Object {
 
             if (!(this.year instanceof org.python.types.Int) && !y.equals("null")) {
                 throw new org.python.exceptions.TypeError("integer argument expected, got " + this.year.typeName());
-
             }
             if (!y.equals("null")) {
                 throw new org.python.exceptions.TypeError("function missing required argument 'month' (pos 2)");
@@ -169,22 +168,10 @@ public class Date extends org.python.types.Object {
     public org.python.types.Str __repr__() {
 
         String year = this.year + "";
-        while (year.length() < 4)
-            year = "0" + year;
-
         String month = this.month + "";
-        while (month.length() < 2)
-            month = "0" + month;
-
         String day = this.day + "";
-        while (day.length() < 2)
-            day = "0" + day;
 
-        return new org.python.types.Str(year + "-" + month + "-" + day);
-    }
-
-    public static org.python.Object constant_4() {
-        return org.python.types.Int.getInt(4);
+        return new org.python.types.Str("datetime.date(" + year + ", " + month + ", " + day + ")");
     }
 
     @org.python.Method(__doc__ = "")
@@ -238,7 +225,6 @@ public class Date extends org.python.types.Object {
 
     @org.python.Method(__doc__ = "")
     public org.python.Object ctime() {
-
         String[] monthList = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
         double monthNum = ((org.python.types.Int) this.month).value;
         String monthStr = monthList[(int) monthNum - 1];
@@ -247,7 +233,7 @@ public class Date extends org.python.types.Object {
         double weekdayNum = ((org.python.types.Int) weekday()).value;
         String weekdayStr = weekdayList[(int) weekdayNum];
 
-        return new org.python.types.Str(weekdayStr + " " + monthStr + "  " + this.day + " 00:00:00 " + this.year);
+        return new org.python.types.Str(weekdayStr + " " + monthStr + " " + this.day + " 00:00:00 " + this.year);
     }
 
     @org.python.Method(__doc__ = "")
@@ -262,6 +248,5 @@ public class Date extends org.python.types.Object {
         int day = c.get(java.util.Calendar.DAY_OF_WEEK);
         int[] convertToPython = { 6, 0, 1, 2, 3, 4, 5 };
         return org.python.types.Int.getInt(convertToPython[day - 1]);
-
     }
 }

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -19,7 +19,7 @@ public class Date extends org.python.types.Object {
     @org.python.Attribute
     public static final org.python.Object max = __max__();
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "date(year, month, day) --> date object")
     public Date(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
 
         super();
@@ -163,7 +163,7 @@ public class Date extends org.python.types.Object {
 
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return repr(self).")
     public org.python.types.Str __repr__() {
 
         String year = this.year + "";
@@ -211,7 +211,7 @@ public class Date extends org.python.types.Object {
 
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Current date or datetime:  same as self.__class__.fromtimestamp(time.time()).")
     public static org.python.Object today() {
         java.time.LocalDateTime today = java.time.LocalDateTime.now();
         int y = today.getYear();
@@ -222,7 +222,7 @@ public class Date extends org.python.types.Object {
         return new Date(args, Collections.emptyMap());
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return ctime() style string.")
     public org.python.Object ctime() {
         String[] monthList = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
         double monthNum = ((org.python.types.Int) this.month).value;
@@ -235,7 +235,7 @@ public class Date extends org.python.types.Object {
         return new org.python.types.Str(weekdayStr + " " + monthStr + " " + this.day + " 00:00:00 " + this.year);
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return the day of the week represented by the date.\nMonday == 0 ... Sunday == 6")
     public org.python.Object weekday() {
         double y = ((org.python.types.Int) this.year).value;
         double m = ((org.python.types.Int) this.month).value;
@@ -249,7 +249,7 @@ public class Date extends org.python.types.Object {
         return org.python.types.Int.getInt(convertToPython[day - 1]);
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self<value.")
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = this._lessThan((Date) other);
@@ -259,7 +259,7 @@ public class Date extends org.python.types.Object {
         }
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self<=value.")
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = this._lessThan((Date) other)
@@ -270,7 +270,7 @@ public class Date extends org.python.types.Object {
         }
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self==value.")
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = this._equals((Date) other);
@@ -280,7 +280,7 @@ public class Date extends org.python.types.Object {
         }
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self!=value.")
     public org.python.Object __ne__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = !(this._equals((Date) other));
@@ -290,7 +290,7 @@ public class Date extends org.python.types.Object {
         }
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self>=value.")
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = !(this._lessThan((Date) other));
@@ -300,7 +300,7 @@ public class Date extends org.python.types.Object {
         }
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return self>value.")
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof Date) {
             boolean res = !(this._lessThan((Date) other))
@@ -335,7 +335,7 @@ public class Date extends org.python.types.Object {
             || (y1 == y2 && m1 == m2 && d1 < d2);
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "Return string in ISO 8601 format, YYYY-MM-DD.")
     public org.python.Object isoformat() {
         long y = ((org.python.types.Int) this.year).value;
         long m = ((org.python.types.Int) this.month).value;
@@ -344,7 +344,7 @@ public class Date extends org.python.types.Object {
         return new org.python.types.Str(res);
     }
 
-    @org.python.Method(__doc__ = "")
+    @org.python.Method(__doc__ = "str -> Construct a date from the output of date.isoformat()")
     public static org.python.Object fromisoformat(org.python.Object dateString) {
         if (dateString instanceof org.python.types.Str) {
             String date = ((org.python.types.Str) dateString).value;

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -62,7 +62,7 @@ public class Date extends org.python.types.Object {
                             daysInMonth[1] = 29;
                         }
 
-                        if (!(1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= daysInMonth[(int) ((org.python.types.Int) this.month).value-1])) {
+                        if (!(1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= daysInMonth[(int) ((org.python.types.Int) this.month).value - 1])) {
                             throw new org.python.exceptions.ValueError("day is out of range for month");
                         }
                     } else {

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -57,8 +57,7 @@ public class Date extends org.python.types.Object {
                 if (python.datetime.MINYEAR.value <= ((org.python.types.Int) this.year).value && ((org.python.types.Int) this.year).value <= python.datetime.MAXYEAR.value) {
 
                     if (1d <= ((org.python.types.Int) this.month).value && ((org.python.types.Int) this.month).value <= 12d) {
-                        if (1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= 31d) {
-                        } else {
+                        if (!(1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= 31d)) {
                             throw new org.python.exceptions.ValueError("day is out of range for month");
                         }
                     } else {
@@ -69,13 +68,13 @@ public class Date extends org.python.types.Object {
                 }
             } else {
                 if (!(this.year instanceof org.python.types.Int)) {
-                    throw new org.python.exceptions.TypeError("integer argument expected, got " + this.year.typeName());
+                    throw new org.python.exceptions.TypeError("an integer is required (got type " + this.year.typeName() + ")");
                 }
                 if (!(this.month instanceof org.python.types.Int)) {
-                    throw new org.python.exceptions.TypeError("integer argument expected, got " + this.month.typeName());
+                    throw new org.python.exceptions.TypeError("an integer is required (got type " + this.month.typeName() + ")");
                 }
                 if (!(this.day instanceof org.python.types.Int)) {
-                    throw new org.python.exceptions.TypeError("integer argument expected, got " + this.day.typeName());
+                    throw new org.python.exceptions.TypeError("an integer is required (got type " + this.day.typeName() + ")");
                 }
             }
         }
@@ -105,14 +104,14 @@ public class Date extends org.python.types.Object {
             String d = this.day + "";
 
             if (!y.equals("null") && !(this.year instanceof org.python.types.Int)) {
-                throw new org.python.exceptions.TypeError("intege argument expected, got " + this.year.typeName());
+                throw new org.python.exceptions.TypeError("an integer is required (got type " + this.year.typeName() + ")");
             }
             if (kwargs.get("year") != null && args.length > 0) {
                 throw new org.python.exceptions.SyntaxError("positional argument follows keyword argument");
             }
 
             if (!(this.month instanceof org.python.types.Int) && !m.equals("null")) {
-                throw new org.python.exceptions.TypeError("integer argument expected, got " + this.month.typeName());
+                throw new org.python.exceptions.TypeError("an integer is required (got type " + this.month.typeName() + ")");
             }
 
             if (y.equals("null")) {
@@ -148,7 +147,7 @@ public class Date extends org.python.types.Object {
             String d = this.day + "";
 
             if (!(this.year instanceof org.python.types.Int) && !y.equals("null")) {
-                throw new org.python.exceptions.TypeError("integer argument expected, got " + this.year.typeName());
+                throw new org.python.exceptions.TypeError("an integer is required (got type " + this.year.typeName() + ")");
             }
             if (!y.equals("null")) {
                 throw new org.python.exceptions.TypeError("function missing required argument 'month' (pos 2)");
@@ -196,7 +195,7 @@ public class Date extends org.python.types.Object {
         org.python.types.Int month = org.python.types.Int.getInt(12);
         org.python.types.Int year = org.python.types.Int.getInt(9999);
 
-        org.python.Object[] args = { year, month, day };
+        org.python.Object[] args = {year, month, day};
         return new Date(args, Collections.emptyMap());
     }
 
@@ -207,7 +206,7 @@ public class Date extends org.python.types.Object {
         org.python.types.Int month = org.python.types.Int.getInt(1);
         org.python.types.Int year = org.python.types.Int.getInt(1);
 
-        org.python.Object[] args = { year, month, day };
+        org.python.Object[] args = {year, month, day};
         return new Date(args, Collections.emptyMap());
 
     }
@@ -219,17 +218,17 @@ public class Date extends org.python.types.Object {
         int m = today.getMonthValue();
         int d = today.getDayOfMonth();
 
-        org.python.Object[] args = { org.python.types.Int.getInt(y), org.python.types.Int.getInt(m), org.python.types.Int.getInt(d) };
+        org.python.Object[] args = {org.python.types.Int.getInt(y), org.python.types.Int.getInt(m), org.python.types.Int.getInt(d)};
         return new Date(args, Collections.emptyMap());
     }
 
     @org.python.Method(__doc__ = "")
     public org.python.Object ctime() {
-        String[] monthList = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+        String[] monthList = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
         double monthNum = ((org.python.types.Int) this.month).value;
         String monthStr = monthList[(int) monthNum - 1];
 
-        String[] weekdayList = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+        String[] weekdayList = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
         double weekdayNum = ((org.python.types.Int) weekday()).value;
         String weekdayStr = weekdayList[(int) weekdayNum];
 
@@ -246,7 +245,7 @@ public class Date extends org.python.types.Object {
         java.util.Calendar c = java.util.Calendar.getInstance();
         c.setTime(myCalendar);
         int day = c.get(java.util.Calendar.DAY_OF_WEEK);
-        int[] convertToPython = { 6, 0, 1, 2, 3, 4, 5 };
+        int[] convertToPython = {6, 0, 1, 2, 3, 4, 5};
         return org.python.types.Int.getInt(convertToPython[day - 1]);
     }
 }

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -55,9 +55,14 @@ public class Date extends org.python.types.Object {
 
             if ((this.year instanceof org.python.types.Int) && (this.month instanceof org.python.types.Int) && (this.day instanceof org.python.types.Int)) {
                 if (python.datetime.MINYEAR.value <= ((org.python.types.Int) this.year).value && ((org.python.types.Int) this.year).value <= python.datetime.MAXYEAR.value) {
-
                     if (1d <= ((org.python.types.Int) this.month).value && ((org.python.types.Int) this.month).value <= 12d) {
-                        if (!(1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= 31d)) {
+                        long[] daysInMonth = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+                        java.util.GregorianCalendar gc = new java.util.GregorianCalendar();
+                        if (gc.isLeapYear((int) ((org.python.types.Int) this.year).value)) {
+                            daysInMonth[1] = 29;
+                        }
+
+                        if (!(1d <= ((org.python.types.Int) this.day).value && ((org.python.types.Int) this.day).value <= daysInMonth[(int) ((org.python.types.Int) this.month).value-1])) {
                             throw new org.python.exceptions.ValueError("day is out of range for month");
                         }
                     } else {
@@ -225,11 +230,11 @@ public class Date extends org.python.types.Object {
     @org.python.Method(__doc__ = "Return ctime() style string.")
     public org.python.Object ctime() {
         String[] monthList = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-        double monthNum = ((org.python.types.Int) this.month).value;
+        long monthNum = ((org.python.types.Int) this.month).value;
         String monthStr = monthList[(int) monthNum - 1];
 
         String[] weekdayList = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-        double weekdayNum = ((org.python.types.Int) weekday()).value;
+        long weekdayNum = ((org.python.types.Int) weekday()).value;
         String weekdayStr = weekdayList[(int) weekdayNum];
 
         return new org.python.types.Str(weekdayStr + " " + monthStr + " " + this.day + " 00:00:00 " + this.year);
@@ -237,9 +242,9 @@ public class Date extends org.python.types.Object {
 
     @org.python.Method(__doc__ = "Return the day of the week represented by the date.\nMonday == 0 ... Sunday == 6")
     public org.python.Object weekday() {
-        double y = ((org.python.types.Int) this.year).value;
-        double m = ((org.python.types.Int) this.month).value;
-        double d = ((org.python.types.Int) this.day).value;
+        long y = ((org.python.types.Int) this.year).value;
+        long m = ((org.python.types.Int) this.month).value;
+        long d = ((org.python.types.Int) this.day).value;
 
         java.util.Date myCalendar = new java.util.GregorianCalendar((int) y, (int) m - 1, (int) d).getTime();
         java.util.Calendar c = java.util.Calendar.getInstance();

--- a/python/common/org/python/stdlib/datetime/Date.java
+++ b/python/common/org/python/stdlib/datetime/Date.java
@@ -334,4 +334,44 @@ public class Date extends org.python.types.Object {
             || (y1 == y2 && m1 < m2)
             || (y1 == y2 && m1 == m2 && d1 < d2);
     }
+
+    @org.python.Method(__doc__ = "")
+    public org.python.Object isoformat() {
+        long y = ((org.python.types.Int) this.year).value;
+        long m = ((org.python.types.Int) this.month).value;
+        long d = ((org.python.types.Int) this.day).value;
+        String res = String.format("%04d-%02d-%02d", y, m, d);
+        return new org.python.types.Str(res);
+    }
+
+    @org.python.Method(__doc__ = "")
+    public static org.python.Object fromisoformat(org.python.Object dateString) {
+        if (dateString instanceof org.python.types.Str) {
+            String date = ((org.python.types.Str) dateString).value;
+            if (date.length() == 10
+                    && Character.isDigit(date.charAt(0))
+                    && Character.isDigit(date.charAt(1))
+                    && Character.isDigit(date.charAt(2))
+                    && Character.isDigit(date.charAt(3))
+                    && date.charAt(4) == '-'
+                    && Character.isDigit(date.charAt(5))
+                    && Character.isDigit(date.charAt(6))
+                    && date.charAt(7) == '-'
+                    && Character.isDigit(date.charAt(8))
+                    && Character.isDigit(date.charAt(9))) {
+                long year = Long.parseLong(date.substring(0, 4));
+                long month = Long.parseLong(date.substring(5, 7));
+                long day = Long.parseLong(date.substring(8, 10));
+                org.python.types.Int d = org.python.types.Int.getInt(day);
+                org.python.types.Int m = org.python.types.Int.getInt(month);
+                org.python.types.Int y = org.python.types.Int.getInt(year);
+                org.python.Object[] args = {y, m, d};
+                return new Date(args, Collections.emptyMap());
+            } else {
+                throw new org.python.exceptions.ValueError("Invalid isoformat string: '" + date + "'");
+            }
+        } else {
+            throw new org.python.exceptions.TypeError("descriptor 'isoformat' for 'datetime.date' objects doesn't apply to a '" + dateString.typeName() + "' object");
+        }
+    }
 }


### PR DESCRIPTION
Provides a partial implementation of Python's `datetime.date`.

Includes:
- Comparison methods
- `isoformat`
- `fromisoformat`

Also includes (minor) bug fixes of already existing functionality:
- Constructor disallowed years above 999 (fixed to match `datetime.MAXYEAR`).
- Some constructor exceptions have wrong error messages (corrected).
- Unused `constant_4` method (removed).
- `__repr__` gives wrong string representation (corrected).
- `ctime` has extra space (corrected).
- Usage of doubles that are actually longs (corrected).
- Constructor allowed any month to have 31 days (corrected to reflect reality, including leap years).


Tested with Java 1.8.0_292 and JUnit v5.7.2.